### PR TITLE
Add the default H parameter on the `Hamt`

### DIFF
--- a/src/immutable.rs
+++ b/src/immutable.rs
@@ -12,7 +12,7 @@ use std::slice;
 /// The structure is immutable from root to leaves, where
 /// each node of this structure is also independently
 /// shareable, including on different thread.
-pub struct Hamt<K, V, H> {
+pub struct Hamt<K, V, H = std::collections::hash_map::DefaultHasher> {
     pub(crate) root: Node<K, V>,
     pub(crate) hasher: PhantomData<H>,
 }

--- a/src/immutable.rs
+++ b/src/immutable.rs
@@ -21,7 +21,7 @@ impl<H, K, V> Clone for Hamt<K, V, H> {
     fn clone(&self) -> Self {
         Hamt {
             root: self.root.clone(),
-            hasher: self.hasher.clone(),
+            hasher: self.hasher,
         }
     }
 }

--- a/src/immutable.rs
+++ b/src/immutable.rs
@@ -108,7 +108,7 @@ impl<H: Hasher + Default, K: Hash + Eq, V> Hamt<K, V, H> {
                 LookupRet::Found(v) => return Some(v),
                 LookupRet::ContinueIn(subnode) => {
                     lvl += 1;
-                    n = &subnode;
+                    n = subnode;
                 }
             }
         }
@@ -137,7 +137,7 @@ impl<'a, K, V> Iterator for HamtIter<'a, K, V> {
             match x {
                 Some(mut iter) => match iter.next() {
                     None => self.content = None,
-                    Some(ref o) => {
+                    Some(o) => {
                         self.content = Some(iter);
                         return Some((&o.0, &o.1));
                     }
@@ -150,7 +150,7 @@ impl<'a, K, V> Iterator for HamtIter<'a, K, V> {
                         }
                         Some(next) => match next.as_ref() {
                             Entry::SubNode(ref sub) => self.stack.push(sub.iter()),
-                            Entry::Leaf(_, ref k, ref v) => return Some((&k, &v)),
+                            Entry::Leaf(_, ref k, ref v) => return Some((k, v)),
                             Entry::LeafMany(_, ref col) => self.content = Some(col.iter()),
                         },
                     },

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,7 +31,6 @@ mod tests {
     use quickcheck::{Arbitrary, Gen};
 
     use std::cmp;
-    use std::collections::hash_map::DefaultHasher;
     use std::collections::BTreeMap;
     use std::hash::Hash;
 
@@ -75,7 +74,7 @@ mod tests {
 
     #[test]
     fn insert_lookup() {
-        let h: Hamt<String, u32, DefaultHasher> = Hamt::new();
+        let h: Hamt<String, u32> = Hamt::new();
 
         let k1 = "ABC".to_string();
         let v1 = 12u32;
@@ -110,7 +109,7 @@ mod tests {
 
     #[test]
     fn dup_insert() {
-        let mut h: Hamt<&String, u32, DefaultHasher> = Hamt::new();
+        let mut h: Hamt<&String, u32> = Hamt::new();
         let dkey = "A".to_string();
         h = h.mutate_freeze(|hm| hm.insert(&dkey, 1)).unwrap();
         assert_eq!(
@@ -121,13 +120,13 @@ mod tests {
 
     #[test]
     fn empty_size() {
-        let h: Hamt<&String, u32, DefaultHasher> = Hamt::new();
+        let h: Hamt<&String, u32> = Hamt::new();
         assert_eq!(h.size(), 0)
     }
 
     #[test]
     fn delete_key_not_exist() {
-        let mut h: Hamt<&String, u32, DefaultHasher> = Hamt::new();
+        let mut h: Hamt<&String, u32> = Hamt::new();
         let dkey = "A".to_string();
         h = h.mutate_freeze(|hm| hm.insert(&dkey, 1)).unwrap();
         assert_eq!(
@@ -139,7 +138,7 @@ mod tests {
 
     #[test]
     fn delete_value_not_match() {
-        let mut h: Hamt<&String, u32, DefaultHasher> = Hamt::new();
+        let mut h: Hamt<&String, u32> = Hamt::new();
         let dkey = "A".to_string();
         h = h.mutate_freeze(|hm| hm.insert(&dkey, 1)).unwrap();
         assert_eq!(
@@ -156,7 +155,7 @@ mod tests {
 
     #[test]
     fn delete() {
-        let mut h: Hamt<String, u32, DefaultHasher> = Hamt::new();
+        let mut h: Hamt<String, u32> = Hamt::new();
 
         let keys = [
             ("KEY1", 10000u32),
@@ -291,7 +290,7 @@ mod tests {
 
     fn property_btreemap_eq<A: Eq + Ord + Hash, B: PartialEq>(
         reference: &BTreeMap<A, B>,
-        h: &Hamt<A, B, DefaultHasher>,
+        h: &Hamt<A, B>,
     ) -> bool {
         // using the btreemap reference as starting point
         for (k, v) in reference.iter() {
@@ -311,7 +310,7 @@ mod tests {
     #[quickcheck]
     fn insert_equivalent(xs: Vec<(String, u32)>) -> bool {
         let mut reference = BTreeMap::new();
-        let mut h: HamtMut<String, u32, DefaultHasher> = HamtMut::new();
+        let mut h: HamtMut<String, u32> = HamtMut::new();
         for (k, v) in xs.iter() {
             if reference.get(k).is_some() {
                 continue;
@@ -343,7 +342,7 @@ mod tests {
     fn large_insert_equivalent(xs: LargeVec<(String, u32)>) -> bool {
         let xs = xs.0;
         let mut reference = BTreeMap::new();
-        let mut h: HamtMut<String, u32, DefaultHasher> = HamtMut::new();
+        let mut h: HamtMut<String, u32> = HamtMut::new();
         for (k, v) in xs.iter() {
             if reference.get(k).is_some() {
                 continue;
@@ -368,7 +367,7 @@ mod tests {
         xs: Plan<K, V>,
         update_f: F,
         replace_with_f: G,
-    ) -> (Hamt<K, V, DefaultHasher>, BTreeMap<K, V>)
+    ) -> (Hamt<K, V>, BTreeMap<K, V>)
     where
         K: Hash + Clone + Eq + Ord + Sync,
         V: Clone + PartialEq + Sync,
@@ -376,7 +375,7 @@ mod tests {
         G: Fn(&V) -> V + Copy,
     {
         let mut reference = BTreeMap::new();
-        let mut h: HamtMut<K, V, DefaultHasher> = HamtMut::new();
+        let mut h: HamtMut<K, V> = HamtMut::new();
         //println!("plan {} operations", xs.0.len());
         for op in xs.0.iter() {
             match op {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -295,13 +295,13 @@ mod tests {
     ) -> bool {
         // using the btreemap reference as starting point
         for (k, v) in reference.iter() {
-            if h.lookup(&k) != Some(v) {
+            if h.lookup(k) != Some(v) {
                 return false;
             }
         }
         // then asking the hamt for any spurious values
         for (k, v) in h.iter() {
-            if reference.get(&k) != Some(v) {
+            if reference.get(k) != Some(v) {
                 return false;
             }
         }

--- a/src/mutable.rs
+++ b/src/mutable.rs
@@ -37,7 +37,7 @@ pub enum ReplaceError {
 /// Once modification happens, then each nodes from
 /// root to leaf will be modified and kept in an
 /// efficient mutable format until freezing.
-pub struct HamtMut<K, V, H> {
+pub struct HamtMut<K, V, H = std::collections::hash_map::DefaultHasher> {
     root: Hamt<K, V, H>,
 }
 

--- a/src/node.rs
+++ b/src/node.rs
@@ -454,7 +454,7 @@ pub fn size_rec<K, V>(node: &Node<K, V>) -> usize {
         match &c.as_ref() {
             Entry::Leaf(_, _, _) => sum += 1,
             Entry::LeafMany(_, col) => sum += col.len(),
-            Entry::SubNode(sub) => sum += size_rec(&sub),
+            Entry::SubNode(sub) => sum += size_rec(sub),
         }
     }
     sum
@@ -472,7 +472,7 @@ pub mod debug {
                 Entry::Leaf(_, _, _) => {}
                 Entry::LeafMany(_, _) => {}
                 Entry::SubNode(sub) => {
-                    let child_depth = depth_rec(&sub);
+                    let child_depth = depth_rec(sub);
                     max_depth = cmp::max(max_depth, child_depth)
                 }
             }


### PR DESCRIPTION
Making use of the DefaultHasher as default H parameter allows to not have to specify it in the code. It's more convenient and more likely to be true most of the time unless users are needing something very specific.

Also added some code cleanup along the way to remove the double reference and unnecessary clone.